### PR TITLE
filter BAM for popscle, zip Souporcell intermediate files, updated or specificy libraries/software

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+**.sif
+Demultiplexing/output

--- a/Demultiplexing/includes/Snakefile_popscle.smk
+++ b/Demultiplexing/includes/Snakefile_popscle.smk
@@ -6,22 +6,24 @@ from glob import glob
 ###################################
 ############# POPSCLE #############
 ###################################
-###### popscle Preprocessing ######
+
+###### popscle bam filter ######
 rule popscle_bam_filter:
     input:
         barcodes = lambda wildcards: scrnaseq_libs_df["Barcode_Files"][wildcards.pool],
         vcf = input_dict["snp_genotypes_filepath"],
         bam = lambda wildcards: scrnaseq_libs_df["Bam_Files"][wildcards.pool],
     output:
-        output_dict["output_dir"] + "/{pool}/popscle/bam_filter"
+        output_dict["output_dir"] + "/{pool}/popscle/bam_filter/{pool}_snpfiltered_alignment.bam"
     resources:
         bam_filter_threads=popscle_dict["bam_filter_threads"],
         mem_per_thread_gb=lambda wildcards, attempt: attempt * popscle_dict["bam_filter_memory"],
         disk_per_thread_gb=0
     threads: popscle_dict["bam_filter_threads"]
     params:
+        tag_group = popscle_dict["tag_group"],
         sif = input_dict["singularity_image"],
-        bind = bind_path
+        bind = bind_path,
         out = output_dict["output_dir"] + "/{pool}/popscle/bam_filter/{pool}_snpfiltered_alignment.bam"
     log: output_dict["output_dir"] + "/logs/popscle_bam_filter.{pool}.log"
     shell:
@@ -29,18 +31,20 @@ rule popscle_bam_filter:
         singularity exec --bind {params.bind} {params.sif} bedtools merge -i {input.vcf} \
             | singularity exec --bind {params.bind} {params.sif} samtools view \
                 -L - \
-                -D CB:<(zcat {input.barcodes}) \
+                -D {params.tag_group}:<(zcat {input.barcodes}) \
                 -o {params.out} \
                 --write-index \
                 -@ {resources.bam_filter_threads} \
                 {input.bam}
         """
 
+###### popscle Preprocessing ######
 rule popscle_pileup:
     input:
         vcf = input_dict["snp_genotypes_filepath"],
         barcodes = lambda wildcards: scrnaseq_libs_df["Barcode_Files"][wildcards.pool],
         bam = output_dict["output_dir"] + "/{pool}/popscle/bam_filter/{pool}_snpfiltered_alignment.bam",
+#        bam = expand(output_dict["output_dir"] + "/popscle/bam_filter/{pool}_snpfiltered_alignment.bam", pool=samples.Pool),
         individuals = lambda wildcards: scrnaseq_libs_df["Individuals_Files"][wildcards.pool]
     output:
         output_dict["output_dir"] + "/{pool}/popscle/pileup/pileup.var.gz"

--- a/Demultiplexing/includes/Snakefile_popscle.smk
+++ b/Demultiplexing/includes/Snakefile_popscle.smk
@@ -45,7 +45,7 @@ rule popscle_pileup:
     input:
         vcf = input_dict["snp_genotypes_filepath"],
         barcodes = lambda wildcards: scrnaseq_libs_df["Barcode_Files"][wildcards.pool],
-        bam = output_dict["output_dir"] + "/{pool}/popscle/bam_filter/{pool}_snpfiltered_alignment.bam",
+        bam = lambda wildcards: output_dict["output_dir"] + "/{wildcards.pool}/popscle/bam_filter/{wildcards.pool}_snpfiltered_alignment.bam",
 #        bam = expand(output_dict["output_dir"] + "/popscle/bam_filter/{pool}_snpfiltered_alignment.bam", pool=samples.Pool),
         individuals = lambda wildcards: scrnaseq_libs_df["Individuals_Files"][wildcards.pool]
     output:

--- a/Demultiplexing/includes/Snakefile_popscle.smk
+++ b/Demultiplexing/includes/Snakefile_popscle.smk
@@ -29,7 +29,7 @@ rule popscle_bam_filter:
     log: output_dict["output_dir"] + "/logs/popscle_bam_filter.{pool}.log"
     shell:
         """
-        mkdir -p {params.out_dir} & \
+        mkdir -p {params.out_dir} && \
         singularity exec --bind {params.bind} {params.sif} bedtools merge -i {input.vcf} \
             | singularity exec --bind {params.bind} {params.sif} samtools view \
                 -L - \

--- a/Demultiplexing/includes/Snakefile_popscle.smk
+++ b/Demultiplexing/includes/Snakefile_popscle.smk
@@ -24,10 +24,12 @@ rule popscle_bam_filter:
         tag_group = popscle_dict["tag_group"],
         sif = input_dict["singularity_image"],
         bind = bind_path,
+        out_dir = output_dict["output_dir"] + "/{pool}/popscle/bam_filter/",
         out = output_dict["output_dir"] + "/{pool}/popscle/bam_filter/{pool}_snpfiltered_alignment.bam"
     log: output_dict["output_dir"] + "/logs/popscle_bam_filter.{pool}.log"
     shell:
         """
+        mkdir -p {params.out_dir} & \
         singularity exec --bind {params.bind} {params.sif} bedtools merge -i {input.vcf} \
             | singularity exec --bind {params.bind} {params.sif} samtools view \
                 -L - \

--- a/Demultiplexing/sceQTL-Gen_Demultiplex.yaml
+++ b/Demultiplexing/sceQTL-Gen_Demultiplex.yaml
@@ -21,6 +21,8 @@ outputs:
 ##### The following arguments are common parameters that may need to be changed depending on the dataset #####
 ##############################################################################################################
 popscle:
+  bam_filter_memory: 10 ### This is the number of gigs that will be used for memory when subsetting the bam file.
+  bam_filter_threads : 4 ### This is the number of threads that will be used for memory when subsetting the bam file.
   pileup_memory: 10 ### This is the number of gigs that will be used for memory and disk space per thread for the pileup step.
   pileup_threads: 10 ### The number threads that will be used for the pileup step
   demuxlet_memory: 25 ### This is the number of gigs that will be used for memory and disk space per thread for the demuxlet step

--- a/Singularity.WGpipeline
+++ b/Singularity.WGpipeline
@@ -10,6 +10,7 @@ From: drneavin/SingularityBaseImages:r363_python368
     #!/bin/bash
     eval "$(command conda 'shell.bash' 'hook' 2> /dev/null)"
     export PATH=/opt/conda/bin/:$PATH
+    yes | apt-get update --allow-releaseinfo-change
     apt update
     yes | apt upgrade
 
@@ -28,6 +29,14 @@ From: drneavin/SingularityBaseImages:r363_python368
 
     cd /opt
         wget https://www.dropbox.com/s/m8u61jn4i1mcktp/TestData4PipelineSmall.tar.gz
+
+    cd
+        wget https://github.com/Kitware/CMake/releases/download/v3.25.2/cmake-3.25.2.tar.gz
+        tar xvf cmake-3.25.2.tar.gz
+        cd cmake-3.25.2
+        ./bootstrap -- -DCMAKE_USE_OPENSSL=OFF
+        make
+        make install
 
     cd /opt
     git clone https://github.com/JonathanShor/DoubletDetection.git
@@ -54,9 +63,10 @@ From: drneavin/SingularityBaseImages:r363_python368
         yes | apt-get install git
 
     cd /opt
-        git https://github.com/sc-eQTLgen-consortium/souporcell.git
-            cd souporcell/troublet
-            git checkout -t RoyOelen/add-fastq-gzipping
+        git clone https://github.com/sc-eQTLgen-consortium/souporcell.git
+            cd souporcell
+            git switch RoyOelen/add-fastq-gzipping
+            cd troublet
             cargo build --release
             cd /opt/souporcell/souporcell
             cargo build --release

--- a/Singularity.WGpipeline
+++ b/Singularity.WGpipeline
@@ -22,14 +22,11 @@ From: drneavin/SingularityBaseImages:r363_python368
     java -version
     wget https://download.oracle.com/java/17/latest/jdk-17_linux-x64_bin.deb
     apt -y install ./jdk-17_linux-x64_bin.deb
-    cat <<EOF | tee /etc/profile.d/jdk.sh
-    export JAVA_HOME=/usr/lib/jvm/jdk-17/
-    export PATH=\$PATH:\$JAVA_HOME/bin
-    EOF
 
     cd /opt
         git clone https://github.com/broadinstitute/picard.git
         cd picard/
+        git checkout tags/2.27.5
         ./gradlew shadowJar
 
     cd /opt

--- a/Singularity.WGpipeline
+++ b/Singularity.WGpipeline
@@ -21,7 +21,7 @@ From: drneavin/SingularityBaseImages:r363_python368
     apt-get install -y openjdk-11-jdk
     java -version
     wget https://download.oracle.com/java/17/latest/jdk-17_linux-x64_bin.deb
-    y | apt install ./jdk-17_linux-x64_bin.deb
+    apt -y install ./jdk-17_linux-x64_bin.deb
     cat <<EOF | tee /etc/profile.d/jdk.sh
     export JAVA_HOME=/usr/lib/jvm/jdk-17/
     export PATH=\$PATH:\$JAVA_HOME/bin

--- a/Singularity.WGpipeline
+++ b/Singularity.WGpipeline
@@ -65,7 +65,7 @@ From: drneavin/SingularityBaseImages:r363_python368
     cd /opt
         git clone https://github.com/sc-eQTLgen-consortium/souporcell.git
             cd souporcell
-            git switch RoyOelen/add-fastq-gzipping
+            git checkout RoyOelen/add-fastq-gzipping
             cd troublet
             cargo build --release
             cd /opt/souporcell/souporcell

--- a/Singularity.WGpipeline
+++ b/Singularity.WGpipeline
@@ -41,6 +41,7 @@ From: drneavin/SingularityBaseImages:r363_python368
     cd /opt
     git clone https://github.com/JonathanShor/DoubletDetection.git
     cd DoubletDetection
+    git checkout tags/v3.0
     /opt/conda/envs/py36/bin/pip install .
 
     cd /opt

--- a/Singularity.WGpipeline
+++ b/Singularity.WGpipeline
@@ -3,10 +3,10 @@ From: drneavin/SingularityBaseImages:r363_python368
 %environment
     export PATH=/opt/DoubletDetection/:/opt/popscle/bin/:/opt:/usr/games:/opt/bedtools2/bin:/opt/conda/envs/py36/bin:/opt/souporcell:/opt/souporcell/troublet/target/release:/opt/conda/bin:/opt/minimap2-2.7:/root/.cargo/bin:/opt/vartrix-v1.1.3-x86_64-linux/:/opt/freebayes/scripts:/opt/freebayes:/opt/vcflib/bin:/opt/vcflib/scripts:$PATH
     export PYTHONPATH=/opt/conda/envs/py36/lib/python3.6/site-packages/
-    export LC_ALL=C 
+    export LC_ALL=C
     alias python=python3
 
-%post 
+%post
     #!/bin/bash
     eval "$(command conda 'shell.bash' 'hook' 2> /dev/null)"
     export PATH=/opt/conda/bin/:$PATH
@@ -54,8 +54,9 @@ From: drneavin/SingularityBaseImages:r363_python368
         yes | apt-get install git
 
     cd /opt
-        git clone https://github.com/wheaton5/souporcell.git
+        git https://github.com/sc-eQTLgen-consortium/souporcell.git
             cd souporcell/troublet
+            git checkout -t RoyOelen/add-fastq-gzipping
             cargo build --release
             cd /opt/souporcell/souporcell
             cargo build --release
@@ -144,7 +145,6 @@ From: drneavin/SingularityBaseImages:r363_python368
 
 
 
-%labels 
+%labels
     Authors Drew Neavin and Anne Senabouth
 	Image_version = 1.0.0
-

--- a/Singularity.WGpipeline
+++ b/Singularity.WGpipeline
@@ -20,7 +20,12 @@ From: drneavin/SingularityBaseImages:r363_python368
 	yes | apt-get install -y python3-tk
     apt-get install -y openjdk-11-jdk
     java -version
-
+    wget https://download.oracle.com/java/17/latest/jdk-17_linux-x64_bin.deb
+    y | apt install ./jdk-17_linux-x64_bin.deb
+    cat <<EOF | tee /etc/profile.d/jdk.sh
+    export JAVA_HOME=/usr/lib/jvm/jdk-17/
+    export PATH=\$PATH:\$JAVA_HOME/bin
+    EOF
 
     cd /opt
         git clone https://github.com/broadinstitute/picard.git


### PR DESCRIPTION
- updated or specificied some libraries and software, so that the image builds again
- using specific fork of Souporcell that zips the alignment files during the realignment step, greatly reducing the filesystem usage
- filter the BAM files used for popscle, to only contain variants that are present in the genotype data, greatly reducing memory usage and runtime for the popscle pileup step